### PR TITLE
feat: add Mitz consent FHIR structure definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,8 @@
+# [1.1.0](https://github.com/martijn-on-fhir/snapshot-builder/compare/v1.0.2...v1.1.0) (2025-09-04)
+
+
+### Features
+
+* add Mitz consent FHIR structure definitions ([e31b268](https://github.com/martijn-on-fhir/snapshot-builder/commit/e31b26855a49cc88c1f53c751f99362fabaa3afa))
+
 ## [1.0.2](https://github.com/martijn-on-fhir/snapshot-builder/compare/v1.0.1...v1.0.2) (2025-09-04)

--- a/input/mitz-base-consent.json
+++ b/input/mitz-base-consent.json
@@ -1,0 +1,271 @@
+{
+  "resourceType": "StructureDefinition",
+  "id": "mitz-base-consent",
+  "language": "nl-NL",
+  "url": "http://vzvz.nl/fhir/otv/StructureDefinition/mitz-base-consent",
+  "version": "4.0.0-beta.1",
+  "name": "MitzBaseConsent",
+  "status": "draft",
+  "publisher": "VZVZ",
+  "contact": [
+    {
+      "name": "VZVZ",
+      "telecom": [
+        {
+          "system": "email",
+          "value": "standaardisatie@vzvz.nl",
+          "use": "work"
+        }
+      ]
+    }
+  ],
+  "description": "This is the base profile of the Mitz Consent profiles. \nThis profile is not intended to be instantiated.",
+  "jurisdiction": [
+    {
+      "coding": [
+        {
+          "code": "NL",
+          "system": "urn:iso:std:iso:3166",
+          "display": "Netherlands"
+        }
+      ]
+    }
+  ],
+  "copyright": "VZVZ",
+  "fhirVersion": "4.0.1",
+  "kind": "resource",
+  "abstract": true,
+  "type": "Consent",
+  "baseDefinition": "http://hl7.org/fhir/StructureDefinition/Consent",
+  "derivation": "constraint",
+  "differential": {
+    "element": [
+      {
+        "id": "Consent.meta",
+        "path": "Consent.meta",
+        "min": 1
+      },
+      {
+        "id": "Consent.meta.profile",
+        "path": "Consent.meta.profile",
+        "comment": "The profile is required",
+        "min": 1
+      },
+      {
+        "id": "Consent.scope",
+        "path": "Consent.scope",
+        "short": "Consent type",
+        "definition": "Type of consent given",
+        "fixedCodeableConcept": {
+          "coding": [
+            {
+              "code": "patient-privacy",
+              "system": "http://terminology.hl7.org/CodeSystem/consentscope"
+            }
+          ]
+        }
+      },
+      {
+        "id": "Consent.category",
+        "path": "Consent.category",
+        "comment": "Category is required but actual data category is defined by the gegevenscategorie or situation code. Therefore fixed value INFA.",
+        "max": "1"
+      },
+      {
+        "id": "Consent.category.coding",
+        "path": "Consent.category.coding",
+        "fixedCoding": {
+          "code": "INFA",
+          "system": "http://terminology.hl7.org/CodeSystem/v3-ActCode"
+        }
+      },
+      {
+        "id": "Consent.patient",
+        "path": "Consent.patient",
+        "comment": "Add the patient object as a reference to allow adding a birthdate",
+        "min": 1
+      },
+      {
+        "id": "Consent.patient.reference",
+        "path": "Consent.patient.reference",
+        "min": 1
+      },
+      {
+        "id": "Consent.dateTime",
+        "path": "Consent.dateTime",
+        "short": "Consent registration date",
+        "definition": "Date and time of consent registration or current date and time if the registration moment is unknown.",
+        "min": 1
+      },
+      {
+        "id": "Consent.organization",
+        "path": "Consent.organization",
+        "comment": "This element is not used because it would always contain Mitz as custodian. \nThis does not provide any added value."
+      },
+      {
+        "id": "Consent.source[x]",
+        "path": "Consent.source[x]",
+        "slicing": {
+          "discriminator": [
+            {
+              "type": "type",
+              "path": "$this"
+            }
+          ],
+          "ordered": false,
+          "rules": "open"
+        }
+      },
+      {
+        "id": "Consent.source[x]:sourceReference",
+        "path": "Consent.source[x]",
+        "sliceName": "sourceReference",
+        "comment": "It is possible to add a reference to the documentation that supports this consent, but the added value is slim.",
+        "min": 0,
+        "max": "1",
+        "type": [
+          {
+            "code": "Reference",
+            "targetProfile": [
+              "http://hl7.org/fhir/StructureDefinition/Consent",
+              "http://hl7.org/fhir/StructureDefinition/DocumentReference",
+              "http://hl7.org/fhir/StructureDefinition/Contract",
+              "http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse"
+            ]
+          }
+        ]
+      },
+      {
+        "id": "Consent.policyRule",
+        "path": "Consent.policyRule",
+        "binding": {
+          "strength": "extensible",
+          "valueSet": "http://vzvz.nl/fhir/otv/ValueSet/policyrule-codes"
+        }
+      },
+      {
+        "id": "Consent.provision.type",
+        "path": "Consent.provision.type",
+        "definition": "Action  to take - permit or deny. Consent is given (permit) or denied (deny) when status is 'active'. \n    When status is inactive, the provision element is absent.",
+        "min": 1
+      },
+      {
+        "id": "Consent.provision.period",
+        "path": "Consent.provision.period",
+        "short": "Validity of consent",
+        "definition": "Period during which the consent is valid"
+      },
+      {
+        "id": "Consent.provision.period.start",
+        "path": "Consent.provision.period.start",
+        "comment": "The start should only be entered when it is noted during registration in which case it is usually equal to the registration date and time."
+      },
+      {
+        "id": "Consent.provision.period.end",
+        "path": "Consent.provision.period.end",
+        "definition": "Optional end date and time of consent. If empty, the consent is given indefinitely."
+      },
+      {
+        "id": "Consent.provision.actor",
+        "path": "Consent.provision.actor",
+        "slicing": {
+          "discriminator": [
+            {
+              "type": "value",
+              "path": "role"
+            }
+          ],
+          "rules": "open",
+          "ordered": false
+        },
+        "min": 1
+      },
+      {
+        "id": "Consent.provision.actor:raadplegend",
+        "path": "Consent.provision.actor",
+        "sliceName": "raadplegend",
+        "short": "Person and Organization or application requesting information",
+        "definition": "A reference to the organization requesting consent information in case of a care provider.",
+        "alias": [
+          "Raadplegende zorgaanbieder"
+        ],
+        "min": 1,
+        "max": "*"
+      },
+      {
+        "id": "Consent.provision.actor:raadplegend.role",
+        "path": "Consent.provision.actor.role",
+        "fixedCodeableConcept": {
+          "coding": [
+            {
+              "code": "110152",
+              "system": "http://dicom.nema.org/resources/ontology/DCM"
+            }
+          ]
+        }
+      },
+      {
+        "id": "Consent.provision.actor:raadplegend.reference",
+        "path": "Consent.provision.actor.reference",
+        "short": "Organization resource",
+        "definition": "A reference to the organization resource this consent relates to",
+        "comment": "Use a reference to an organization to provide the organization type.\n      Set the organization type using the Nictiz RoleCodeNLZorgaanbiederType Codesystem (see https://simplifier.net/Nictiz-R4-zib2020/organization-type/~overview)",
+        "type": [
+          {
+            "code": "Reference",
+            "targetProfile": [
+              "http://hl7.org/fhir/StructureDefinition/Organization",
+              "http://nictiz.nl/fhir/StructureDefinition/nl-core-HealthcareProvider-Organization"
+            ]
+          }
+        ]
+      },
+      {
+        "id": "Consent.provision.actor:dossierhoudend",
+        "path": "Consent.provision.actor",
+        "sliceName": "dossierhoudend",
+        "short": "Custodian of the medical record",
+        "definition": "Organization resource referring to a specific organization or specific type of organization that has the requested information",
+        "alias": [
+          "Dossierhoudende zorgaanbieder"
+        ],
+        "min": 0,
+        "max": "1"
+      },
+      {
+        "id": "Consent.provision.actor:dossierhoudend.role",
+        "path": "Consent.provision.actor.role",
+        "fixedCodeableConcept": {
+          "coding": [
+            {
+              "code": "110153",
+              "system": "http://dicom.nema.org/resources/ontology/DCM"
+            }
+          ]
+        }
+      },
+      {
+        "id": "Consent.provision.actor:dossierhoudend.reference",
+        "path": "Consent.provision.actor.reference",
+        "short": "Organization resource",
+        "definition": "A reference to the organization resource this consent relates to",
+        "comment": "Use a reference to an organization to provide the organization type.\n      Set the organization type using the Nictiz RoleCodeNLZorgaanbiederType Codesystem (see https://simplifier.net/Nictiz-R4-zib2020/organization-type/~overview)",
+        "type": [
+          {
+            "code": "Reference",
+            "targetProfile": [
+              "http://hl7.org/fhir/StructureDefinition/Organization",
+              "http://nictiz.nl/fhir/StructureDefinition/nl-core-HealthcareProvider-Organization"
+            ]
+          }
+        ]
+      },
+      {
+        "id": "Consent.provision.code",
+        "path": "Consent.provision.code",
+        "short": "Data category",
+        "definition": "This code indicates the data category the consent pertains to"
+      }
+    ]
+  }
+}

--- a/input/mitz-consent-migrate.json
+++ b/input/mitz-consent-migrate.json
@@ -1,0 +1,88 @@
+{
+  "resourceType": "StructureDefinition",
+  "id": "mitz-consent-migrate",
+  "language": "nl-NL",
+  "url": "http://vzvz.nl/fhir/otv/StructureDefinition/mitz-consent-migrate",
+  "version": "4.0.0-beta.1",
+  "name": "MitzConsentMigrate",
+  "status": "draft",
+  "publisher": "VZVZ",
+  "contact": [
+    {
+      "name": "VZVZ",
+      "telecom": [
+        {
+          "system": "email",
+          "value": "standaardisatie@vzvz.nl",
+          "use": "work"
+        }
+      ]
+    }
+  ],
+  "description": "This profile is used to migrate local consents to the Mitz registry",
+  "jurisdiction": [
+    {
+      "coding": [
+        {
+          "code": "NL",
+          "system": "urn:iso:std:iso:3166",
+          "display": "Netherlands"
+        }
+      ]
+    }
+  ],
+  "copyright": "VZVZ",
+  "fhirVersion": "4.0.1",
+  "kind": "resource",
+  "abstract": false,
+  "type": "Consent",
+  "baseDefinition": "http://vzvz.nl/fhir/otv/StructureDefinition/mitz-base-consent",
+  "derivation": "constraint",
+  "differential": {
+    "element": [
+      {
+        "id": "Consent.status",
+        "path": "Consent.status",
+        "fixedCode": "active"
+      },
+      {
+        "id": "Consent.policyRule",
+        "path": "Consent.policyRule",
+        "comment": "PolicyRule is required therefore a fixed value to indicate the Mitz connector as provider of these consents",
+        "fixedCodeableConcept": {
+          "coding": [
+            {
+              "code": "MC",
+              "system": "http://vzvz.nl/fhir/otv/CodeSystem/toestemmingbron"
+            }
+          ]
+        }
+      },
+      {
+        "id": "Consent.provision.actor:raadplegend",
+        "path": "Consent.provision.actor",
+        "sliceName": "raadplegend",
+        "definition": "Consulting providers. Only applicable in migrations where consent is explicitly limited to a specific group of providers.",
+        "comment": "Add a contained organization with a type set to the category of providers that is allowed"
+      },
+      {
+        "id": "Consent.provision.purpose",
+        "path": "Consent.provision.purpose",
+        "short": "Kind of treatment",
+        "comment": "Fixed value TREAT, because a migration is never in case of emergency",
+        "fixedCoding": {
+          "code": "TREAT",
+          "system": "http://terminology.hl7.org/CodeSystem/v3-ActReason"
+        }
+      },
+      {
+        "id": "Consent.provision.code",
+        "path": "Consent.provision.code",
+        "binding": {
+          "strength": "required",
+          "valueSet": "http://vzvz.nl/fhir/otv/ValueSet/gegevenscategorie"
+        }
+      }
+    ]
+  }
+}

--- a/input/mitz-consent-notify.json
+++ b/input/mitz-consent-notify.json
@@ -1,0 +1,127 @@
+{
+  "resourceType": "StructureDefinition",
+  "id": "mitz-consent-notify",
+  "language": "nl-NL",
+  "url": "http://vzvz.nl/fhir/otv/StructureDefinition/mitz-consent-notify",
+  "version": "4.0.0-beta.1",
+  "name": "MitzConsentNotify",
+  "status": "draft",
+  "publisher": "VZVZ",
+  "contact": [
+    {
+      "name": "VZVZ",
+      "telecom": [
+        {
+          "system": "email",
+          "value": "standaardisatie@vzvz.nl",
+          "use": "work"
+        }
+      ]
+    }
+  ],
+  "description": "Notification of the care provider of the consent change by the patient.\nThis notification is the result of the subscription taken by the care provider.",
+  "jurisdiction": [
+    {
+      "coding": [
+        {
+          "code": "NL",
+          "system": "urn:iso:std:iso:3166",
+          "display": "Netherlands"
+        }
+      ]
+    }
+  ],
+  "copyright": "VZVZ",
+  "fhirVersion": "4.0.1",
+  "kind": "resource",
+  "abstract": false,
+  "type": "Consent",
+  "baseDefinition": "http://vzvz.nl/fhir/otv/StructureDefinition/mitz-base-consent",
+  "derivation": "constraint",
+  "differential": {
+    "element": [
+      {
+        "id": "Consent.text",
+        "path": "Consent.text",
+        "short": "Text representation of the consent, for human interpretation",
+        "definition": "A human-readable narrative that describes the consent",
+        "comment": "The text element is required, but will be filled by the Mitz server",
+        "min": 1
+      },
+      {
+        "id": "Consent.text.status",
+        "path": "Consent.text.status",
+        "patternCode": "generated"
+      },
+      {
+        "id": "Consent.status",
+        "path": "Consent.status",
+        "definition": "Indicates the current state of this consent. \nInactive for unanswered consent questions, active for answered consent questions, regardless of the answer."
+      },
+      {
+        "id": "Consent.policyRule",
+        "path": "Consent.policyRule",
+        "comment": "PolicyRule needs to be present, therefore a fixed value to indicate Mitz is the provider",
+        "min": 1
+      },
+      {
+        "id": "Consent.policyRule.coding",
+        "path": "Consent.policyRule.coding",
+        "min": 1,
+        "max": "1",
+        "fixedCoding": {
+          "code": "MITZ",
+          "system": "http://vzvz.nl/fhir/otv/CodeSystem/toestemmingbron"
+        }
+      },
+      {
+        "id": "Consent.provision.actor",
+        "path": "Consent.provision.actor",
+        "min": 2
+      },
+      {
+        "id": "Consent.provision.actor:raadplegend",
+        "path": "Consent.provision.actor",
+        "sliceName": "raadplegend",
+        "comment": "For every organization type an actor with role 'Raadplegend' is created \n    with a reference to an Organization type with the appropriate role type"
+      },
+      {
+        "id": "Consent.provision.actor:dossierhoudend",
+        "path": "Consent.provision.actor",
+        "sliceName": "dossierhoudend",
+        "definition": "The care provider whose subscription triggered this notification",
+        "min": 1
+      },
+      {
+        "id": "Consent.provision.purpose",
+        "path": "Consent.provision.purpose",
+        "short": "Kind of treatment",
+        "definition": "Regular or emergency treatment",
+        "min": 1,
+        "max": "1"
+      },
+      {
+        "id": "Consent.provision.purpose.system",
+        "path": "Consent.provision.purpose.system",
+        "min": 1,
+        "fixedUri": "http://terminology.hl7.org/CodeSystem/v3-ActReason"
+      },
+      {
+        "id": "Consent.provision.purpose.code",
+        "path": "Consent.provision.purpose.code",
+        "short": "Kind of treatment",
+        "definition": "TREAT for regular treatment or ETREAT in case of emergency",
+        "min": 1
+      },
+      {
+        "id": "Consent.provision.code",
+        "path": "Consent.provision.code",
+        "definition": "The data category or categories the consent pertains to.\n    In case there are multilpe data categories, the provision.type is valid for all of them.",
+        "binding": {
+          "strength": "required",
+          "valueSet": "http://vzvz.nl/fhir/otv/ValueSet/gegevenscategorie"
+        }
+      }
+    ]
+  }
+}

--- a/input/mitz-consent-provider.json
+++ b/input/mitz-consent-provider.json
@@ -1,0 +1,79 @@
+{
+  "resourceType": "StructureDefinition",
+  "id": "mitz-consent-provider",
+  "language": "nl-NL",
+  "url": "http://vzvz.nl/fhir/otv/StructureDefinition/mitz-consent-provider",
+  "version": "4.0.0-beta.1",
+  "name": "MitzConsentProvider",
+  "status": "draft",
+  "publisher": "VZVZ",
+  "contact": [
+    {
+      "name": "VZVZ",
+      "telecom": [
+        {
+          "system": "email",
+          "value": "standaardisatie@vzvz.nl",
+          "use": "work"
+        }
+      ]
+    }
+  ],
+  "description": "Notification of a care provider to Mitz registry that the \n'consent button' is used on behalf of the patient",
+  "jurisdiction": [
+    {
+      "coding": [
+        {
+          "code": "NL",
+          "system": "urn:iso:std:iso:3166",
+          "display": "Netherlands"
+        }
+      ]
+    }
+  ],
+  "copyright": "VZVZ",
+  "fhirVersion": "4.0.1",
+  "kind": "resource",
+  "abstract": false,
+  "type": "Consent",
+  "baseDefinition": "http://vzvz.nl/fhir/otv/StructureDefinition/mitz-base-consent",
+  "derivation": "constraint",
+  "differential": {
+    "element": [
+      {
+        "id": "Consent.status",
+        "path": "Consent.status",
+        "fixedCode": "active"
+      },
+      {
+        "id": "Consent.policyRule",
+        "path": "Consent.policyRule",
+        "comment": "PolicyRule is required therefore a fixed value to indicate the Mitz connector as provider of these consents",
+        "fixedCodeableConcept": {
+          "coding": [
+            {
+              "code": "MC",
+              "system": "http://vzvz.nl/fhir/otv/CodeSystem/toestemmingbron"
+            }
+          ]
+        }
+      },
+      {
+        "id": "Consent.provision.actor:dossierhoudend",
+        "path": "Consent.provision.actor",
+        "sliceName": "dossierhoudend",
+        "definition": "Source provider. Only required when the consent is given to a specific provider."
+      },
+      {
+        "id": "Consent.provision.code",
+        "path": "Consent.provision.code",
+        "short": "Situation code",
+        "definition": "Situation code",
+        "binding": {
+          "strength": "required",
+          "valueSet": "http://vzvz.nl/fhir/otv/ValueSet/situatiecode"
+        }
+      }
+    ]
+  }
+}

--- a/input/mitz-consent-request.json
+++ b/input/mitz-consent-request.json
@@ -1,0 +1,266 @@
+{
+  "resourceType": "StructureDefinition",
+  "id": "mitz-consent-request",
+  "language": "nl-NL",
+  "url": "http://vzvz.nl/fhir/otv/StructureDefinition/mitz-consent-request",
+  "version": "4.0.0-beta.1",
+  "name": "MitzConsentRequest",
+  "status": "draft",
+  "publisher": "VZVZ",
+  "contact": [
+    {
+      "name": "VZVZ",
+      "telecom": [
+        {
+          "system": "email",
+          "value": "standaardisatie@vzvz.nl",
+          "use": "work"
+        }
+      ]
+    }
+  ],
+  "description": "Profile to request if consent is given for the exchange of information between the provided care providers \nor to request which care providers are allowed to exchange information for this paient",
+  "jurisdiction": [
+    {
+      "coding": [
+        {
+          "code": "NL",
+          "system": "urn:iso:std:iso:3166",
+          "display": "Netherlands"
+        }
+      ]
+    }
+  ],
+  "copyright": "VZVZ",
+  "fhirVersion": "4.0.1",
+  "kind": "resource",
+  "abstract": false,
+  "type": "Consent",
+  "baseDefinition": "http://hl7.org/fhir/StructureDefinition/Consent",
+  "derivation": "constraint",
+  "differential": {
+    "element": [
+      {
+        "id": "Consent.meta",
+        "path": "Consent.meta",
+        "min": 1
+      },
+      {
+        "id": "Consent.meta.profile",
+        "path": "Consent.meta.profile",
+        "comment": "The profile is required",
+        "min": 1
+      },
+      {
+        "id": "Consent.extension",
+        "path": "Consent.extension",
+        "slicing": {
+          "discriminator": [
+            {
+              "type": "value",
+              "path": "url"
+            }
+          ],
+          "rules": "open"
+        },
+        "min": 1
+      },
+      {
+        "id": "Consent.extension:regulatoryBasis",
+        "path": "Consent.extension",
+        "sliceName": "regulatoryBasis",
+        "min": 1,
+        "max": "*",
+        "type": [
+          {
+            "code": "Extension",
+            "profile": [
+              "http://vzvz.nl/fhir/otv/StructureDefinition/regulatoryBasis"
+            ]
+          }
+        ]
+      },
+      {
+        "id": "Consent.status",
+        "path": "Consent.status",
+        "fixedCode": "proposed"
+      },
+      {
+        "id": "Consent.scope",
+        "path": "Consent.scope",
+        "short": "Consent type",
+        "definition": "Type of consent given",
+        "fixedCodeableConcept": {
+          "coding": [
+            {
+              "code": "patient-privacy",
+              "system": "http://terminology.hl7.org/CodeSystem/consentscope"
+            }
+          ]
+        }
+      },
+      {
+        "id": "Consent.category",
+        "path": "Consent.category",
+        "comment": "Category is required but actual data category is defined in provision.code. Therefore fixed value INFA.",
+        "max": "1"
+      },
+      {
+        "id": "Consent.category.coding",
+        "path": "Consent.category.coding",
+        "fixedCoding": {
+          "code": "INFA",
+          "system": "http://terminology.hl7.org/CodeSystem/v3-ActCode"
+        }
+      },
+      {
+        "id": "Consent.patient",
+        "path": "Consent.patient",
+        "min": 1,
+        "type": [
+          {
+            "code": "Reference",
+            "targetProfile": [
+              "http://hl7.org/fhir/StructureDefinition/Patient",
+              "http://nictiz.nl/fhir/StructureDefinition/nl-core-Patient"
+            ]
+          }
+        ]
+      },
+      {
+        "id": "Consent.patient.reference",
+        "path": "Consent.patient.reference",
+        "max": "0"
+      },
+      {
+        "id": "Consent.patient.identifier",
+        "path": "Consent.patient.identifier",
+        "min": 1
+      },
+      {
+        "id": "Consent.patient.identifier.system",
+        "path": "Consent.patient.identifier.system",
+        "binding": {
+          "strength": "required",
+          "valueSet": "http://vzvz.nl/fhir/otv/ValueSet/patientidentifiers"
+        }
+      },
+      {
+        "id": "Consent.policyRule",
+        "path": "Consent.policyRule",
+        "fixedCodeableConcept": {
+          "coding": [
+            {
+              "code": "MITZ",
+              "system": "http://vzvz.nl/fhir/otv/CodeSystem/toestemmingbron"
+            }
+          ]
+        },
+        "binding": {
+          "strength": "extensible",
+          "valueSet": "http://vzvz.nl/fhir/otv/ValueSet/policyrule-codes"
+        }
+      },
+      {
+        "id": "Consent.provision.actor",
+        "path": "Consent.provision.actor",
+        "slicing": {
+          "discriminator": [
+            {
+              "type": "value",
+              "path": "role"
+            }
+          ],
+          "rules": "open",
+          "ordered": false
+        }
+      },
+      {
+        "id": "Consent.provision.actor:raadplegend",
+        "path": "Consent.provision.actor",
+        "sliceName": "raadplegend",
+        "short": "Person and Organization or application requesting information",
+        "definition": "A reference to the person and organization requesting consent information in case of a care provider.\nIf the person requesting the consent information is the patient itself, \nthen the reference points to a device which contains the identifier of the application of the person.\nIn turn the device points to the id of the patient, with an id that is appropriate for the context.",
+        "min": 0,
+        "max": "1"
+      },
+      {
+        "id": "Consent.provision.actor:raadplegend.role",
+        "path": "Consent.provision.actor.role",
+        "fixedCodeableConcept": {
+          "coding": [
+            {
+              "code": "110152",
+              "system": "http://dicom.nema.org/resources/ontology/DCM"
+            }
+          ]
+        }
+      },
+      {
+        "id": "Consent.provision.actor:raadplegend.reference",
+        "path": "Consent.provision.actor.reference",
+        "short": "Responsible practitioner or organization",
+        "definition": "A practitionerRole containing the reference to the practitioner and the organization.\nOr a reference to a device acting on behalf of a patient performing the request.",
+        "type": [
+          {
+            "code": "Reference",
+            "targetProfile": [
+              "http://hl7.org/fhir/StructureDefinition/PractitionerRole",
+              "http://nictiz.nl/fhir/StructureDefinition/nl-core-HealthProfessional-PractitionerRole",
+              "http://vzvz.nl/fhir/StructureDefinition/nl-vzvz-Device"
+            ],
+            "aggregation": [
+              "contained"
+            ]
+          }
+        ]
+      },
+      {
+        "id": "Consent.provision.actor:dossierhoudend",
+        "path": "Consent.provision.actor",
+        "sliceName": "dossierhoudend",
+        "short": "Organization providing the information",
+        "definition": "Organization resource referring to a specific organization or specific type of organization that has the requested information.\nIf the request is closed, there should be an URA identifying the organization.\nIf the request is open, there is only a role type if the request is for a specific role type, otherwise there is no reference to an organization",
+        "min": 0,
+        "max": "1"
+      },
+      {
+        "id": "Consent.provision.actor:dossierhoudend.role",
+        "path": "Consent.provision.actor.role",
+        "fixedCodeableConcept": {
+          "coding": [
+            {
+              "code": "110153",
+              "system": "http://dicom.nema.org/resources/ontology/DCM"
+            }
+          ]
+        }
+      },
+      {
+        "id": "Consent.provision.actor:dossierhoudend.reference",
+        "path": "Consent.provision.actor.reference",
+        "type": [
+          {
+            "code": "Reference",
+            "targetProfile": [
+              "http://hl7.org/fhir/StructureDefinition/Organization",
+              "http://nictiz.nl/fhir/StructureDefinition/nl-core-HealthcareProvider-Organization"
+            ],
+            "aggregation": [
+              "contained"
+            ]
+          }
+        ]
+      },
+      {
+        "id": "Consent.provision.code",
+        "path": "Consent.provision.code",
+        "definition": "Classification of the consent statement",
+        "binding": {
+          "strength": "extensible",
+          "valueSet": "http://vzvz.nl/fhir/otv/ValueSet/gegevenscategorie"
+        }
+      }
+    ]
+  }
+}

--- a/input/mitz-consent-response.json
+++ b/input/mitz-consent-response.json
@@ -1,0 +1,67 @@
+{
+  "resourceType": "StructureDefinition",
+  "id": "mitz-consent-response",
+  "language": "nl-NL",
+  "url": "http://vzvz.nl/fhir/otv/StructureDefinition/mitz-consent-response",
+  "version": "4.0.0-beta.1",
+  "name": "MitzConsentResponse",
+  "title": "Mitz Consent Response",
+  "status": "draft",
+  "publisher": "VZVZ",
+  "contact": [
+    {
+      "name": "VZVZ",
+      "telecom": [
+        {
+          "system": "email",
+          "value": "standaardisatie@vzvz.nl",
+          "use": "work"
+        }
+      ]
+    }
+  ],
+  "description": "OperationOutcome to express a permit/deny response",
+  "jurisdiction": [
+    {
+      "coding": [
+        {
+          "code": "NL",
+          "system": "urn:iso:std:iso:3166",
+          "display": "Netherlands"
+        }
+      ]
+    }
+  ],
+  "copyright": "VZVZ",
+  "fhirVersion": "4.0.1",
+  "kind": "resource",
+  "abstract": false,
+  "type": "OperationOutcome",
+  "baseDefinition": "http://hl7.org/fhir/StructureDefinition/OperationOutcome",
+  "derivation": "constraint",
+  "differential": {
+    "element": [
+      {
+        "id": "OperationOutcome",
+        "path": "OperationOutcome",
+        "constraint": [
+          {
+            "key": "oo-1",
+            "severity": "error",
+            "human": "If a consent response is given, the severity should be information and the code informational",
+            "expression": "issue.where(details.coding.system.contains('http://vzvz.nl/fhir/otv/CodeSystem/consent-response')).all(code = 'informational' and severity = 'information')",
+            "source": "http://vzvz.nl/fhir/otv/StructureDefinition/mitz-consent-response"
+          }
+        ]
+      },
+      {
+        "id": "OperationOutcome.issue.details",
+        "path": "OperationOutcome.issue.details",
+        "binding": {
+          "strength": "extensible",
+          "valueSet": "http://hl7.org/fhir/ValueSet/consent-provision-type"
+        }
+      }
+    ]
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "snapshorbuilder",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "snapshorbuilder",
-      "version": "1.0.2",
+      "version": "1.1.0",
       "dependencies": {
         "@semantic-release/changelog": "^6.0.3",
         "@semantic-release/exec": "^7.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "snapshotbuilder",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "A TypeScript/Node.js tool for generating FHIR snapshots from differential StructureDefinitions, specifically designed for processing Dutch healthcare standards (ZiB) and FHIR R4 resources.",
   "author": "Martijn Schimmel",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- Added six new FHIR StructureDefinition profiles for Dutch healthcare consent management through VZVZ/Mitz infrastructure
- Includes base consent profile and specialized profiles for migration, notifications, provider interactions, requests, and responses
- Enables standardized healthcare consent management in the Dutch healthcare system

## Test plan
- [ ] Build project to verify JSON structure validity: `npm run build`
- [ ] Generate snapshots for new profiles: `npm run snapshot [profile-name]`  
- [ ] Validate profiles against FHIR R4 specification

🤖 Generated with [Claude Code](https://claude.ai/code)